### PR TITLE
AccountsDialog: Ellipsize/Truncate account dispaly name

### DIFF
--- a/src/empathy-accounts-dialog.c
+++ b/src/empathy-accounts-dialog.c
@@ -51,7 +51,7 @@
 /* The primary text of the dialog shown to the user when he is about to lose
  * unsaved changes */
 #define PENDING_CHANGES_QUESTION_PRIMARY_TEXT \
-  _("There are unsaved modifications to your %s account.")
+  _("There are unsaved modifications to your %.50s account.")
 /* The primary text of the dialog shown to the user when he is about to lose
  * an unsaved new account */
 #define UNSAVED_NEW_ACCOUNT_QUESTION_PRIMARY_TEXT \
@@ -184,7 +184,7 @@ accounts_dialog_update_name_label (EmpathyAccountsDialog *dialog,
   gchar *text;
   EmpathyAccountsDialogPriv *priv = GET_PRIV (dialog);
 
-  text = g_markup_printf_escaped ("<b>%s</b>", display_name);
+  text = g_markup_printf_escaped ("<b>%.50s</b>", display_name);
   gtk_label_set_markup (GTK_LABEL (priv->label_name), text);
 
   g_free (text);
@@ -1251,7 +1251,7 @@ accounts_dialog_remove_account_iter (EmpathyAccountsDialog *dialog,
     }
 
   question_dialog_primary_text = g_strdup_printf (
-      _("Do you want to remove %s from your computer?"),
+      _("Do you want to remove %.50s from your computer?"),
       tp_account_get_display_name (account));
 
   accounts_dialog_show_question_dialog (dialog, question_dialog_primary_text,
@@ -2384,6 +2384,7 @@ accounts_dialog_build_ui (EmpathyAccountsDialog *dialog)
 
   /* first row */
   priv->label_name = gtk_label_new (NULL);
+  gtk_label_set_ellipsize (GTK_LABEL (priv->label_name), PANGO_ELLIPSIZE_END);
   gtk_grid_attach (GTK_GRID (grid), priv->label_name, 1, 0, 1, 1);
 
   /* second row */


### PR DESCRIPTION
This fix gnome-shell crash if the name is too big,
because it makes the window huge.

https://bugzilla.gnome.org/show_bug.cgi?id=702095